### PR TITLE
fixup! MediaCodec

### DIFF
--- a/media/codec2/sfplugin/CCodecConfig.cpp
+++ b/media/codec2/sfplugin/CCodecConfig.cpp
@@ -1151,11 +1151,14 @@ bool CCodecConfig::updateFormats(Domain domain) {
 
     bool changed = false;
     if (domain & mInputDomain) {
-        sp<AMessage> oldFormat = mInputFormat->dup();
+        sp<AMessage> oldFormat = mInputFormat;
+        mInputFormat = mInputFormat->dup(); // trigger format changed
         mInputFormat->extend(getFormatForDomain(reflected, mInputDomain));
         if (mInputFormat->countEntries() != oldFormat->countEntries()
                 || mInputFormat->changesFrom(oldFormat)->countEntries() > 0) {
             changed = true;
+        } else {
+            mInputFormat = oldFormat; // no change
         }
     }
     if (domain & mOutputDomain) {

--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -5283,34 +5283,6 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                     if (mChannelMaskPresent) {
                         notify->setInt32("channel-mask", mChannelMask);
                     }
-
-                    if (!mIsEncoder && portIndex == kPortIndexOutput) {
-                        AString mime;
-                        if (mConfigFormat->findString("mime", &mime)
-                                && !strcasecmp(MEDIA_MIMETYPE_AUDIO_AAC, mime.c_str())) {
-
-                            OMX_AUDIO_PARAM_ANDROID_AACDRCPRESENTATIONTYPE presentation;
-                            InitOMXParams(&presentation);
-                            err = mOMXNode->getParameter(
-                                    (OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAacDrcPresentation,
-                                    &presentation, sizeof(presentation));
-                            if (err != OK) {
-                                return err;
-                            }
-                            notify->setInt32("aac-encoded-target-level",
-                                             presentation.nEncodedTargetLevel);
-                            notify->setInt32("aac-drc-cut-level", presentation.nDrcCut);
-                            notify->setInt32("aac-drc-boost-level", presentation.nDrcBoost);
-                            notify->setInt32("aac-drc-heavy-compression",
-                                             presentation.nHeavyCompression);
-                            notify->setInt32("aac-target-ref-level",
-                                             presentation.nTargetReferenceLevel);
-                            notify->setInt32("aac-drc-effect-type", presentation.nDrcEffectType);
-                            notify->setInt32("aac-drc-album-mode", presentation.nDrcAlbumMode);
-                            notify->setInt32("aac-drc-output-loudness",
-                                             presentation.nDrcOutputLoudness);
-                        }
-                    }
                     break;
                 }
 
@@ -7732,58 +7704,6 @@ status_t ACodec::setParameters(const sp<AMessage> &params) {
     // Ignore errors as failure is expected for codecs that aren't video encoders.
     (void)configureTemporalLayers(params, false /* inConfigure */, mOutputFormat);
 
-    AString mime;
-    if (!mIsEncoder
-            && (mConfigFormat->findString("mime", &mime))
-            && !strcasecmp(MEDIA_MIMETYPE_AUDIO_AAC, mime.c_str())) {
-        OMX_AUDIO_PARAM_ANDROID_AACDRCPRESENTATIONTYPE presentation;
-        InitOMXParams(&presentation);
-        mOMXNode->getParameter(
-                    (OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAacDrcPresentation,
-                    &presentation, sizeof(presentation));
-        int32_t value32 = 0;
-        bool updated = false;
-        if (params->findInt32("aac-pcm-limiter-enable", &value32)) {
-            presentation.nPCMLimiterEnable = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-encoded-target-level", &value32)) {
-            presentation.nEncodedTargetLevel = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-drc-cut-level", &value32)) {
-            presentation.nDrcCut = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-drc-boost-level", &value32)) {
-            presentation.nDrcBoost = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-drc-heavy-compression", &value32)) {
-            presentation.nHeavyCompression = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-target-ref-level", &value32)) {
-            presentation.nTargetReferenceLevel = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-drc-effect-type", &value32)) {
-            presentation.nDrcEffectType = value32;
-            updated = true;
-        }
-        if (params->findInt32("aac-drc-album-mode", &value32)) {
-            presentation.nDrcAlbumMode = value32;
-            updated = true;
-        }
-        if (!params->findInt32("aac-drc-output-loudness", &value32)) {
-            presentation.nDrcOutputLoudness = value32;
-            updated = true;
-        }
-        if (updated) {
-            mOMXNode->setParameter((OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAacDrcPresentation,
-                &presentation, sizeof(presentation));
-        }
-    }
     return setVendorParameters(params);
 }
 

--- a/media/libstagefright/codecs/aacdec/SoftAAC2.cpp
+++ b/media/libstagefright/codecs/aacdec/SoftAAC2.cpp
@@ -38,7 +38,6 @@
 #define DRC_DEFAULT_MOBILE_DRC_HEAVY 1   /* switch for heavy compression for mobile conf */
 #define DRC_DEFAULT_MOBILE_DRC_EFFECT 3  /* MPEG-D DRC effect type; 3 => Limited playback range */
 #define DRC_DEFAULT_MOBILE_DRC_ALBUM 0  /* MPEG-D DRC album mode; 0 => album mode is disabled, 1 => album mode is enabled */
-#define DRC_DEFAULT_MOBILE_OUTPUT_LOUDNESS -1 /* decoder output loudness; -1 => the value is unknown, otherwise dB step value (e.g. 64 for -16 dB) */
 #define DRC_DEFAULT_MOBILE_ENC_LEVEL (-1) /* encoder target level; -1 => the value is unknown, otherwise dB step value (e.g. 64 for -16 dB) */
 #define MAX_CHANNEL_COUNT            8  /* maximum number of audio channels that can be decoded */
 // names of properties that can be used to override the default DRC settings
@@ -231,15 +230,6 @@ status_t SoftAAC2::initDecoder() {
     // For seven and eight channel input streams, enable 6.1 and 7.1 channel output
     aacDecoder_SetParam(mAACDecoder, AAC_PCM_MAX_OUTPUT_CHANNELS, -1);
 
-    mDrcCompressMode = DRC_DEFAULT_MOBILE_DRC_HEAVY;
-    mDrcTargetRefLevel = DRC_DEFAULT_MOBILE_REF_LEVEL;
-    mDrcEncTargetLevel = DRC_DEFAULT_MOBILE_ENC_LEVEL;
-    mDrcBoostFactor = DRC_DEFAULT_MOBILE_DRC_BOOST;
-    mDrcAttenuationFactor = DRC_DEFAULT_MOBILE_DRC_CUT;
-    mDrcEffectType = DRC_DEFAULT_MOBILE_DRC_EFFECT;
-    mDrcAlbumMode = DRC_DEFAULT_MOBILE_DRC_ALBUM;
-    mDrcOutputLoudness = DRC_DEFAULT_MOBILE_OUTPUT_LOUDNESS;
-
     return status;
 }
 
@@ -368,27 +358,6 @@ OMX_ERRORTYPE SoftAAC2::internalGetParameter(
             return OMX_ErrorNone;
         }
 
-        case OMX_IndexParamAudioAndroidAacDrcPresentation:
-        {
-             OMX_AUDIO_PARAM_ANDROID_AACDRCPRESENTATIONTYPE *aacPresParams =
-                    (OMX_AUDIO_PARAM_ANDROID_AACDRCPRESENTATIONTYPE *)params;
-
-            ALOGD("get OMX_IndexParamAudioAndroidAacDrcPresentation");
-
-            if (!isValidOMXParam(aacPresParams)) {
-                return OMX_ErrorBadParameter;
-            }
-            aacPresParams->nDrcEffectType = mDrcEffectType;
-            aacPresParams->nDrcAlbumMode = mDrcAlbumMode;
-            aacPresParams->nDrcBoost =  mDrcBoostFactor;
-            aacPresParams->nDrcCut = mDrcAttenuationFactor;
-            aacPresParams->nHeavyCompression = mDrcCompressMode;
-            aacPresParams->nTargetReferenceLevel = mDrcTargetRefLevel;
-            aacPresParams->nEncodedTargetLevel = mDrcEncTargetLevel;
-            aacPresParams ->nDrcOutputLoudness = mDrcOutputLoudness;
-            return OMX_ErrorNone;
-        }
-
         default:
             return SimpleSoftOMXComponent::internalGetParameter(index, params);
     }
@@ -495,13 +464,11 @@ OMX_ERRORTYPE SoftAAC2::internalSetParameter(
             if (aacPresParams->nDrcEffectType >= -1) {
                 ALOGV("set nDrcEffectType=%d", aacPresParams->nDrcEffectType);
                 aacDecoder_SetParam(mAACDecoder, AAC_UNIDRC_SET_EFFECT, aacPresParams->nDrcEffectType);
-                mDrcEffectType = aacPresParams->nDrcEffectType;
             }
             if (aacPresParams->nDrcAlbumMode >= -1) {
                 ALOGV("set nDrcAlbumMode=%d", aacPresParams->nDrcAlbumMode);
                 aacDecoder_SetParam(mAACDecoder, AAC_UNIDRC_ALBUM_MODE,
                         aacPresParams->nDrcAlbumMode);
-                mDrcAlbumMode = aacPresParams->nDrcAlbumMode;
             }
             bool updateDrcWrapper = false;
             if (aacPresParams->nDrcBoost >= 0) {
@@ -509,41 +476,33 @@ OMX_ERRORTYPE SoftAAC2::internalSetParameter(
                 mDrcWrap.setParam(DRC_PRES_MODE_WRAP_DESIRED_BOOST_FACTOR,
                         aacPresParams->nDrcBoost);
                 updateDrcWrapper = true;
-                mDrcBoostFactor = aacPresParams->nDrcBoost;
             }
             if (aacPresParams->nDrcCut >= 0) {
                 ALOGV("set nDrcCut=%d", aacPresParams->nDrcCut);
                 mDrcWrap.setParam(DRC_PRES_MODE_WRAP_DESIRED_ATT_FACTOR, aacPresParams->nDrcCut);
                 updateDrcWrapper = true;
-                mDrcAttenuationFactor = aacPresParams->nDrcCut;
             }
             if (aacPresParams->nHeavyCompression >= 0) {
                 ALOGV("set nHeavyCompression=%d", aacPresParams->nHeavyCompression);
                 mDrcWrap.setParam(DRC_PRES_MODE_WRAP_DESIRED_HEAVY,
                         aacPresParams->nHeavyCompression);
                 updateDrcWrapper = true;
-                mDrcCompressMode = aacPresParams->nHeavyCompression;
             }
             if (aacPresParams->nTargetReferenceLevel >= -1) {
                 ALOGV("set nTargetReferenceLevel=%d", aacPresParams->nTargetReferenceLevel);
                 mDrcWrap.setParam(DRC_PRES_MODE_WRAP_DESIRED_TARGET,
                         aacPresParams->nTargetReferenceLevel);
                 updateDrcWrapper = true;
-                mDrcTargetRefLevel = aacPresParams->nTargetReferenceLevel;
             }
             if (aacPresParams->nEncodedTargetLevel >= 0) {
                 ALOGV("set nEncodedTargetLevel=%d", aacPresParams->nEncodedTargetLevel);
                 mDrcWrap.setParam(DRC_PRES_MODE_WRAP_ENCODER_TARGET,
                         aacPresParams->nEncodedTargetLevel);
                 updateDrcWrapper = true;
-                mDrcEncTargetLevel = aacPresParams->nEncodedTargetLevel;
             }
             if (aacPresParams->nPCMLimiterEnable >= 0) {
                 aacDecoder_SetParam(mAACDecoder, AAC_PCM_LIMITER_ENABLE,
                         (aacPresParams->nPCMLimiterEnable != 0));
-            }
-            if (aacPresParams ->nDrcOutputLoudness != DRC_DEFAULT_MOBILE_OUTPUT_LOUDNESS) {
-                mDrcOutputLoudness = aacPresParams ->nDrcOutputLoudness;
             }
             if (updateDrcWrapper) {
                 mDrcWrap.update();
@@ -893,11 +852,6 @@ void SoftAAC2::onQueueFilled(OMX_U32 /* portIndex */) {
                     mBufferSizes.add(n);
 
                     // fall through
-                }
-
-                if ( mDrcOutputLoudness != mStreamInfo->outputLoudness) {
-                    ALOGD("update Loudness, before = %d, now = %d", mDrcOutputLoudness, mStreamInfo->outputLoudness);
-                    mDrcOutputLoudness = mStreamInfo->outputLoudness;
                 }
 
                 /*

--- a/media/libstagefright/codecs/aacdec/SoftAAC2.h
+++ b/media/libstagefright/codecs/aacdec/SoftAAC2.h
@@ -85,17 +85,6 @@ private:
     int32_t mOutputDelayRingBufferWritePos;
     int32_t mOutputDelayRingBufferReadPos;
     int32_t mOutputDelayRingBufferFilled;
-
-    //drc
-    int32_t mDrcCompressMode;
-    int32_t mDrcTargetRefLevel;
-    int32_t mDrcEncTargetLevel;
-    int32_t mDrcBoostFactor;
-    int32_t mDrcAttenuationFactor;
-    int32_t mDrcEffectType;
-    int32_t mDrcAlbumMode;
-    int32_t mDrcOutputLoudness;
-
     bool outputDelayRingBufferPutSamples(INT_PCM *samples, int numSamples);
     int32_t outputDelayRingBufferGetSamples(INT_PCM *samples, int numSamples);
     int32_t outputDelayRingBufferSamplesAvailable();

--- a/media/libstagefright/omx/SimpleSoftOMXComponent.cpp
+++ b/media/libstagefright/omx/SimpleSoftOMXComponent.cpp
@@ -17,10 +17,6 @@
 //#define LOG_NDEBUG 0
 #define LOG_TAG "SimpleSoftOMXComponent"
 #include <utils/Log.h>
-#include <OMX_Core.h>
-#include <OMX_Audio.h>
-#include <OMX_IndexExt.h>
-#include <OMX_AudioExt.h>
 
 #include <media/stagefright/omx/SimpleSoftOMXComponent.h>
 #include <media/stagefright/foundation/ADebug.h>
@@ -78,7 +74,7 @@ bool SimpleSoftOMXComponent::isSetParameterAllowed(
 
     OMX_U32 portIndex;
 
-    switch ((int)index) {
+    switch (index) {
         case OMX_IndexParamPortDefinition:
         {
             const OMX_PARAM_PORTDEFINITIONTYPE *portDefs =
@@ -111,19 +107,6 @@ bool SimpleSoftOMXComponent::isSetParameterAllowed(
             portIndex = aacMode->nPortIndex;
             break;
         }
-
-         case OMX_IndexParamAudioAndroidAacDrcPresentation:
-        {
-            if (mState == OMX_StateInvalid) {
-                return false;
-            }
-            const OMX_AUDIO_PARAM_ANDROID_AACDRCPRESENTATIONTYPE *aacPresParams =
-                            (const OMX_AUDIO_PARAM_ANDROID_AACDRCPRESENTATIONTYPE *)params;
-            if (!isValidOMXParam(aacPresParams)) {
-                return false;
-            }
-            return true;
-         }
 
         default:
             return false;


### PR DESCRIPTION
* W MediaCodecRenderer: Failed to initialize decoder: OMX.google.aac.decoder
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:   android.media.MediaCodec$CodecException: Error 0xfffffc0e
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at android.media.MediaCodec.native_configure(Native Method)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at android.media.MediaCodec.configure(MediaCodec.java:2127)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at android.media.MediaCodec.configure(MediaCodec.java:2043)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.b1.w.Z(MediaCodecAudioRenderer.java:8)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.g1.f.u0(MediaCodecRenderer.java:10)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.g1.f.z0(MediaCodecRenderer.java:14)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.g1.f.y0(MediaCodecRenderer.java:15)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.g1.f.C0(MediaCodecRenderer.java:9)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.b1.w.C0(MediaCodecAudioRenderer.java:1)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.g1.f.K0(MediaCodecRenderer.java:4)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.g1.f.y(MediaCodecRenderer.java:6)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.b0.h(ExoPlayerImplInternal.java:14)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at com.google.android.exoplayer2.b0.handleMessage(ExoPlayerImplInternal.java:17)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at android.os.Handler.dispatchMessage(Handler.java:102)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at android.os.Looper.loop(Looper.java:223)
03-02 23:50:18.099  3024 21060 W MediaCodecRenderer:       at android.os.HandlerThread.run(HandlerThread.java:67)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal: Renderer error: index=1, type=audio, format=Format(3, null, null, audio/mp4a-latm, mp4a.40.2, 319000, null, [-1, -1, -1.0], [2, 44100]), rendererSupport=YES
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:   com.google.android.exoplayer2.x: com.google.android.exoplayer2.g1.f$a: Decoder init failed: OMX.google.aac.decoder, Format(3, null, null, audio/mp4a-latm, mp4a.40.2, 319000, null, [-1, -1, -1.0], [2, 44100])
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.s.g(BaseRenderer.java:7)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.y0(MediaCodecRenderer.java:16)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.C0(MediaCodecRenderer.java:9)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.b1.w.C0(MediaCodecAudioRenderer.java:1)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.K0(MediaCodecRenderer.java:4)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.y(MediaCodecRenderer.java:6)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.b0.h(ExoPlayerImplInternal.java:14)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.b0.handleMessage(ExoPlayerImplInternal.java:17)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at android.os.Handler.dispatchMessage(Handler.java:102)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at android.os.Looper.loop(Looper.java:223)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at android.os.HandlerThread.run(HandlerThread.java:67)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:   Caused by: com.google.android.exoplayer2.g1.f$a: Decoder init failed: OMX.google.aac.decoder, Format(3, null, null, audio/mp4a-latm, mp4a.40.2, 319000, null, [-1, -1, -1.0], [2, 44100])
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.z0(MediaCodecRenderer.java:17)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.y0(MediaCodecRenderer.java:15)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       ... 9 more
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:   Caused by: android.media.MediaCodec$CodecException: Error 0xfffffc0e
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at android.media.MediaCodec.native_configure(Native Method)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at android.media.MediaCodec.configure(MediaCodec.java:2127)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at android.media.MediaCodec.configure(MediaCodec.java:2043)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.b1.w.Z(MediaCodecAudioRenderer.java:8)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.u0(MediaCodecRenderer.java:10)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       at com.google.android.exoplayer2.g1.f.z0(MediaCodecRenderer.java:14)
03-02 23:50:18.099  3024 21060 E ExoPlayerImplInternal:       ... 10 more
03-02 23:50:18.101  3633  3633 E ContrastColorUtil: background can not be translucent: #0
03-02 23:50:18.102  3024 21086 I BpBinder: onLastStrongRef automatically unlinking death recipients: android.media.IResourceManagerService
03-02 23:50:18.102  3633  3633 E ContrastColorUtil: background can not be translucent: #ffffff
03-02 23:50:18.105  3633  3633 W ConstraintSet: id unknown center_vertical_guideline
03-02 23:50:18.106  3633  3633 W ConstraintSet: id unknown media_action_barrier
03-02 23:50:18.106  3633  3633 W ConstraintSet: id unknown media_text
03-02 23:50:18.106  3633  3633 W ConstraintSet: id unknown remove_text
03-02 23:50:18.106  3633  3633 W ConstraintSet: id unknown settings
03-02 23:50:18.106  3633  3633 W ConstraintSet: id unknown cancel
03-02 23:50:18.106  3633  3633 W ConstraintSet: id unknown dismiss
03-02 23:50:18.109  3633  3633 E ContrastColorUtil: background can not be translucent: #0
03-02 23:50:18.121  3024 20770 W FA      : Value is too long; discarded. Value kind, name, value length: param, error_message, 151
03-02 23:50:18.121  3024 20770 W FA      : Value is too long; discarded. Value kind, name, value length: param, error_uri, 542
03-02 23:50:18.125  1688  3322 I MediaFocusControl: abandonAudioFocus() from uid/pid 10412/3024 clientId=android.media.AudioManager@e4b0b79com.wynk.player.exo.player.ExoPlayer2@cd463ba
03-02 23:50:18.126  3024  3024 I ExoPlayerImpl: Release 196fda4 [ExoPlayerLib/2.11.7] [OnePlus6T, ONEPLUS A6013, OnePlus, 30] [goog.exo.core, goog.exo.hls, goog.exo.okhttp]
03-02 23:50:18.131  6141 15146 V Avrcp_ext: onMetadataChanged

Change-Id: I823ea994d6566db77f737c4c0fb263aae65fa8bd
Signed-off-by: chandu078 <chandudyavanapelli03@gmail.com>